### PR TITLE
Fix module not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
     "name":             "react-native-webview-crosswalk",
     "version":          "0.0.25",
     "description":      "Crosswalk's WebView for React Native on Android",
-    "main":             "index.js",
     "scripts":          {},
     "version":          "0.4.0",
     "description":      "Crosswalk's WebView for React Native on Android",


### PR DESCRIPTION
Into the package.json the main porperty specify the file will be used for the  npm  module resolver but in this case index.js  dosen't exist. if I remove this property recat-native module resolver chosse the correct index file according the platform (.android.js or ios.js) and it works